### PR TITLE
feat: Civ23Umiのゲーム設定を調整しました。革命ターン数の決定方法をCiv2Civ3に合わせ、AI特性をランダムから固定にしま…

### DIFF
--- a/rulesets/civ23umi/game.ruleset
+++ b/rulesets/civ23umi/game.ruleset
@@ -2181,8 +2181,8 @@ set =
       "techlevel", 0
       "foggedborders", "ENABLED"
       "unreachableprotects", "DISABLED"
+      "revolentype", "RANDQUICK"
       "huts", 0
-      "traitdistribution", "EVEN"
       "endturn", 240
       "airliftingstyle", "FROM_ALLIES|TO_ALLIES"
       "sciencebox", 180
@@ -2199,6 +2199,6 @@ set =
       "unitwaittime", 15
       "scorelog", "ENABLED"
       "persistentready", "CONNECTED"
-      "allowtake", "H3A3h3a3do"
+      "allowtake", "H3A3h3a3d3o"
       "iphide", "ENABLED"
     }


### PR DESCRIPTION
…した。また、ゲーム開始後に死亡したプレイヤーの接続を乗っ取れないようにしました。